### PR TITLE
add missing v

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
         run: |
           MODULE_NAME=$(grep "^module" go.mod | awk -F'/' '{print $NF}')
           BINARY_VERSION=$(echo ${{ steps.current-version.outputs.version }})
-          ARCHIVE="${MODULE_NAME}_${BINARY_VERSION}_${{ matrix.os }}_${{ matrix.arch }}.zip"
+          ARCHIVE="${MODULE_NAME}_v${BINARY_VERSION}_${{ matrix.os }}_${{ matrix.arch }}.zip"
 
           # Conditionally set the binary name with or without .exe extension
           BINARY="${MODULE_NAME}_${BINARY_VERSION}"
@@ -118,6 +118,6 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
-          name: ${{ steps.prepare-release.outputs.module_name }}_${{ steps.prepare-release.outputs.binary_version }}_${{ matrix.os }}_${{ matrix.arch }}
+          name: ${{ steps.prepare-release.outputs.module_name }}_v${{ steps.prepare-release.outputs.binary_version }}_${{ matrix.os }}_${{ matrix.arch }}
           path: |
             ${{ steps.prepare-release.outputs.archive }}


### PR DESCRIPTION
## 🎟️ Tracking

[SM-1604](https://bitwarden.atlassian.net/browse/SM-1604)

## 📔 Objective

Fix SM-1604 - the released artifact appears to be missing the 'v' character, which causes the .zip not to unpack when installed via tofu init


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[SM-1604]: https://bitwarden.atlassian.net/browse/SM-1604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ